### PR TITLE
admin: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,24 @@
+<!--
+    Tag your PR title with the components that it touches along with
+    the type of change (feat, fix, refactor)
+    E.g. "fix: fix activity 1 button placement" or "feat: add favicon and make footer thinner"
+-->
+
+## Summary
+
+Closes #<!-- issue number -->
+
+### What was changed?
+
+-
+
+### Why were these changes made?
+
+-
+
+## Testing
+
+<!--
+    How did you manually test your change? How do you know that your code works?
+    Add supporting screenshots of the feature in play, terminal pastes, etc. as necessary
+-->


### PR DESCRIPTION
## Summary
Adding a PR template so we can maintain better coding practices and better support the long-term development of this project. Don't have to strictly follow this, but this is a good way to start having better PRs!

### What was changed?
- I added a PR template (um borrowed from TeachLA without permission lol)

### Why were these changes made?
- A PR template helps standardize the PRs and reduces churn over confusion about who's changes did what
- Also makes it easier to document and track issues within the PR itself

## Testing
N/A
