### PR TITLE
feat: sliding animation for right-side bar

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -13,6 +13,7 @@ $dars-panel-background-color: rgb(0 183 255);
   flex-direction: row;
   justify-content: center;
   align-items: center;
+  background-color: $dars-panel-background-color;
 }
 
 #classes,
@@ -28,7 +29,24 @@ $dars-panel-background-color: rgb(0 183 255);
 
 #dars {
   background-color: $dars-panel-background-color;
+}
+
+.hide {
+  width: 0;
+  -webkit-transition: width, 0.4s linear;
+  -moz-transition: width, 0.4s linear;
+  -ms-transition: width, 0.4s linear;
+  -o-transition: width, 0.4s linear;
+  transition: width, 0.4s linear;
+}
+
+.visible {
   width: 30%;
+  -webkit-transition: width, 0.4s linear;
+  -moz-transition: width, 0.4s linear;
+  -ms-transition: width, 0.4s linear;
+  -o-transition: width, 0.4s linear;
+  transition: width, 0.4s linear;
 }
 
 #main {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,6 @@ function App(): JSX.Element {
   ];
 
   const handleCourseClick = (courseId: number) => {
-    console.log('courseId: ', courseId);
     if (courseId < 0) {
       setSelectedCourse(null);
       return;
@@ -83,11 +82,9 @@ function App(): JSX.Element {
           selected={selectedCourse ? selectedCourse.id : -1}
         ></ClassGraph>
       </div>
-      {selectedCourse ? (
-        <div id="dars">
-          <CourseDetails course={selectedCourse}></CourseDetails>
-        </div>
-      ) : null}
+      <div id="dars" className={selectedCourse ? 'visible' : 'hide'}>
+        <CourseDetails course={selectedCourse}></CourseDetails>
+      </div>
     </div>
   );
 }

--- a/src/components/CourseDetails.tsx
+++ b/src/components/CourseDetails.tsx
@@ -2,9 +2,12 @@ import React, { useState } from 'react';
 import { Course } from '../App';
 
 interface CourseDetailsProps {
-  course: Course;
+  course: Course | null;
 }
 const CourseDetails = ({ course }: CourseDetailsProps) => {
+  if (!course) {
+    return <div></div>;
+  }
   return (
     <div>
       <div>


### PR DESCRIPTION
## Summary

### What was changed?
- Move the conditional rendering to inside the `CourseDetails` component
- Instead of conditional rendering in `App`, we swap the class to enable the animation
- Animate by using width from 0 -> 20%

### Why were these changes made?
- The smooth sliding animation is a better UX than it randomly popping in and out of existence

## Testing
https://github.com/UCLA-Noms/class-graph/assets/13056466/1d21df8b-7971-4f14-8f3a-73a1512eee13
- Feel free to adjust or outright replace this animation. This is just a very simple sliding one so it's not as much of an eyesore
  - Personally, I think it's a little too slow
